### PR TITLE
Generify crop aging process for Butterfly AI goal.

### DIFF
--- a/src/main/java/com/pugz/bloomful/common/entity/ai/LandOnPlantGoal.java
+++ b/src/main/java/com/pugz/bloomful/common/entity/ai/LandOnPlantGoal.java
@@ -4,11 +4,13 @@ import com.pugz.bloomful.common.entity.ButterflyEntity;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.goal.MoveToBlockGoal;
 import net.minecraft.particles.ParticleTypes;
+import net.minecraft.state.IProperty;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 
+import java.util.Collection;
 import java.util.Random;
 
 public class LandOnPlantGoal extends MoveToBlockGoal {
@@ -38,18 +40,13 @@ public class LandOnPlantGoal extends MoveToBlockGoal {
             BlockState blockstate = world.getBlockState(blockpos);
             Block block = blockstate.getBlock();
             if (block instanceof CropsBlock) {
-                if (block instanceof BeetrootBlock) {
-                    Integer integer = blockstate.get(BeetrootBlock.BEETROOT_AGE);
-                    if (integer < 3) {
-                        world.setBlockState(blockpos, blockstate.with(BeetrootBlock.BEETROOT_AGE, integer + 1), 2);
-                    }
+                CropsBlock crop = (CropsBlock) block;
+                IProperty<Integer> prop = crop.getAgeProperty();
+                int age = blockstate.get(prop);
+                if (age < crop.getMaxAge()) {
+                    world.setBlockState(blockpos, blockstate.with(prop, age + 1), 2);
                 }
-                else {
-                    Integer integer = blockstate.get(CropsBlock.AGE);
-                    if (integer < 7) {
-                        world.setBlockState(blockpos, blockstate.with(CropsBlock.AGE, integer + 1), 2);
-                    }
-                }
+
                 double d0 = random.nextGaussian() * 0.02D;
                 double d1 = random.nextGaussian() * 0.02D;
                 double d2 = random.nextGaussian() * 0.02D;


### PR DESCRIPTION
Currently it's possible for the butterfly to land on a plant that is a
derivative of CropsBlock but implements its own age property, that is
also not a beetroot, and it will cause the following server crash:

```
java.lang.IllegalArgumentException: Cannot get property IntegerProperty{name=age, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7]} as it does not exist in Block{druidcraft:hemp_crop}
	at net.minecraft.state.StateHolder.func_177229_b(SourceFile:95) ~[?:?] {re:classloading}
	at com.pugz.bloomful.common.entity.ai.LandOnPlantGoal.func_75246_d(LandOnPlantGoal.java:48) ~[?:?] {re:classloading}
	at net.minecraft.entity.ai.goal.PrioritizedGoal.func_75246_d(SourceFile:55) ~[?:?] {re:classloading}
	at com.performant.coremod.entity.ai.CustomGoalSelector.func_75774_a(CustomGoalSelector.java:247) ~[?:1.14.4-1.3] {re:classloading}
	at net.minecraft.entity.MobEntity.func_70626_be(MobEntity.java:590) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.entity.LivingEntity.func_70636_d(LivingEntity.java:2186) ~[?:?] {re:classloading,pl:accesstransformer:B,xf:fml:caelus:coremodone,pl:runtimedistcleaner:A}
	at net.minecraft.entity.MobEntity.func_70636_d(MobEntity.java:460) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.entity.LivingEntity.func_70071_h_(LivingEntity.java:2032) ~[?:?] {re:classloading,pl:accesstransformer:B,xf:fml:caelus:coremodone,pl:runtimedistcleaner:A}
	at net.minecraft.entity.MobEntity.func_70071_h_(MobEntity.java:274) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at com.pugz.bloomful.common.entity.ButterflyEntity.func_70071_h_(ButterflyEntity.java:118) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.func_217479_a(ServerWorld.java:587) ~[?:?] {re:classloading,xf:fml:quark:change-sleeping-player-count,xf:fml:quark:add-rave-hook,pl:runtimedistcleaner:A}
	at net.minecraft.world.World.func_217390_a(World.java:684) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.func_72835_b(ServerWorld.java:394) ~[?:?] {re:classloading,xf:fml:quark:change-sleeping-player-count,xf:fml:quark:add-rave-hook,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:829) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:324) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:764) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:622) [?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181] {}
```

This is a simple fix which changes the code to use the `getAgeProperty`
method (which should be overriden by any block which doesn't use the
default CropsBlock.AGE property) and then the max age (likewise) to
increase the crop's growth.